### PR TITLE
Update check-checksums.rb

### DIFF
--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -53,13 +53,14 @@ class Checksum < Sensu::Plugin::Check::CLI
       unknown 'We have nothing to compare this file with.'
     end
 
-    hash = config[:hash] || Digest::SHA2.file(files.first).hexdigest
+    hashfile = config[:hash] || Digest::SHA2.file(files.first).hexdigest
+    hash = IO.read(hashfile).chomp
 
     errors = []
 
     files.each do |file|
       if File.exist?(file)
-        file_hash = Digest::SHA2.file(file).hexdigest
+        file_hash = Digest::SHA2.file(file).hexdigest.chomp
         errors << "#{file} does not match" if file_hash != hash
       else
         errors << "#{file} does not exist"


### PR DESCRIPTION
Just changed a couple lines to allow reading sha2sum from a file instead of feeding it directly to the command. 
Lines 56-57:
Added this part to allow reading a hash from a premade file
i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
so you can do:
/etc/sensu/plugins/check-checksums.rb -f filename -h filename.sha256sum
Lines 57, 63:
Added .chomp so newlines won't get in the way of comparisons (doesn't change anything if there is no newline)
