### PR TITLE
Update check-checksums.rb

### DIFF
--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -34,25 +34,23 @@ class Checksum < Sensu::Plugin::Check::CLI
          short: '-f FILES',
          long: '--files FILES',
          required: true
-         
+        
   option :hash,
          description: 'The hash these files must hash as. If unspecified the files will be compared to the first file.',
          short: '-h SHA2HASH',
          long: '--hash SHA2HASH'
-         
-         
+        
   option :hashfile,
          description: 'The file containing the hash these files must hash as.',
          # i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
          short: '-H SHA2HASHFILE',
          long: '--hashfile SHA2HASHFILE'
-         
+        
   option :warn_only,
          description: "Warn instead of critical if they don't match",
          short: '-w',
          long: '--warn-only',
          boolean: true
-
   def run
     files = config[:files].split(',')
     
@@ -76,7 +74,7 @@ class Checksum < Sensu::Plugin::Check::CLI
         errors << "#{file} does not exist"
       end
     end
-
+    
     if errors.length > 0 && config[:warn_only]
       warning errors.join("\n")
     elsif errors.length > 0
@@ -84,5 +82,6 @@ class Checksum < Sensu::Plugin::Check::CLI
     else
       ok 'Files match.'
     end
+    
   end
 end

--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -39,6 +39,12 @@ class Checksum < Sensu::Plugin::Check::CLI
          description: 'The hash these files must hash as. If unspecified the files will be compared to the first file.',
          short: '-h SHA2HASH',
          long: '--hash SHA2HASH'
+  
+  option :hashfile,
+         description: 'The file containing the hash these files must hash as.',
+         # i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
+         short: '-H SHA2HASHFILE',
+         long: '--hashfile SHA2HASHFILE'
 
   option :warn_only,
          description: "Warn instead of critical if they don't match",
@@ -49,17 +55,21 @@ class Checksum < Sensu::Plugin::Check::CLI
   def run
     files = config[:files].split(',')
 
-    if files.length == 1 && !config[:hash]
+    if files.length == 1 && !config[:hash] && !config[:hashfile]
       unknown 'We have nothing to compare this file with.'
     end
-
-    hash = config[:hash] || Digest::SHA2.file(files.first).hexdigest
-
+    
+    if config[:hashfile]
+      hash = IO.read(config[:hashfile]).chomp
+    else
+      hash = config[:hash] || Digest::SHA2.file(files.first).hexdigest
+    end 
+    
     errors = []
 
     files.each do |file|
       if File.exist?(file)
-        file_hash = Digest::SHA2.file(file).hexdigest
+        file_hash = Digest::SHA2.file(file).hexdigest.chomp
         errors << "#{file} does not match" if file_hash != hash
       else
         errors << "#{file} does not exist"

--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -34,38 +34,40 @@ class Checksum < Sensu::Plugin::Check::CLI
          short: '-f FILES',
          long: '--files FILES',
          required: true
-        
+  
   option :hash,
          description: 'The hash these files must hash as. If unspecified the files will be compared to the first file.',
          short: '-h SHA2HASH',
          long: '--hash SHA2HASH'
-        
+  
   option :hashfile,
          description: 'The file containing the hash these files must hash as.',
          # i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
          short: '-H SHA2HASHFILE',
          long: '--hashfile SHA2HASHFILE'
-        
+  
   option :warn_only,
          description: "Warn instead of critical if they don't match",
          short: '-w',
          long: '--warn-only',
          boolean: true
+
   def run
+
     files = config[:files].split(',')
-    
+
     if files.length == 1 && !config[:hash] && !config[:hashfile]
       unknown 'We have nothing to compare this file with.'
     end
-    
+
     if config[:hashfile]
       hash = IO.read(config[:hashfile]).chomp
     else
       hash = config[:hash] || Digest::SHA2.file(files.first).hexdigest
     end
-    
+
     errors = []
-    
+
     files.each do |file|
       if File.exist?(file)
         file_hash = Digest::SHA2.file(file).hexdigest.chomp
@@ -74,7 +76,7 @@ class Checksum < Sensu::Plugin::Check::CLI
         errors << "#{file} does not exist"
       end
     end
-    
+
     if errors.length > 0 && config[:warn_only]
       warning errors.join("\n")
     elsif errors.length > 0
@@ -82,6 +84,6 @@ class Checksum < Sensu::Plugin::Check::CLI
     else
       ok 'Files match.'
     end
-    
+
   end
 end

--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -34,18 +34,18 @@ class Checksum < Sensu::Plugin::Check::CLI
          short: '-f FILES',
          long: '--files FILES',
          required: true
-  
+
   option :hash,
          description: 'The hash these files must hash as. If unspecified the files will be compared to the first file.',
          short: '-h SHA2HASH',
          long: '--hash SHA2HASH'
-  
+
   option :hashfile,
          description: 'The file containing the hash these files must hash as.',
          # i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
          short: '-H SHA2HASHFILE',
          long: '--hashfile SHA2HASHFILE'
-  
+
   option :warn_only,
          description: "Warn instead of critical if they don't match",
          short: '-w',
@@ -53,7 +53,6 @@ class Checksum < Sensu::Plugin::Check::CLI
          boolean: true
 
   def run
-
     files = config[:files].split(',')
 
     if files.length == 1 && !config[:hash] && !config[:hashfile]
@@ -84,6 +83,5 @@ class Checksum < Sensu::Plugin::Check::CLI
     else
       ok 'Files match.'
     end
-
   end
 end

--- a/bin/check-checksums.rb
+++ b/bin/check-checksums.rb
@@ -34,18 +34,19 @@ class Checksum < Sensu::Plugin::Check::CLI
          short: '-f FILES',
          long: '--files FILES',
          required: true
-
+         
   option :hash,
          description: 'The hash these files must hash as. If unspecified the files will be compared to the first file.',
          short: '-h SHA2HASH',
          long: '--hash SHA2HASH'
-  
+         
+         
   option :hashfile,
          description: 'The file containing the hash these files must hash as.',
          # i.e. sha256sum filename | awk '{print $1}' > filename.sha256sum
          short: '-H SHA2HASHFILE',
          long: '--hashfile SHA2HASHFILE'
-
+         
   option :warn_only,
          description: "Warn instead of critical if they don't match",
          short: '-w',
@@ -54,7 +55,7 @@ class Checksum < Sensu::Plugin::Check::CLI
 
   def run
     files = config[:files].split(',')
-
+    
     if files.length == 1 && !config[:hash] && !config[:hashfile]
       unknown 'We have nothing to compare this file with.'
     end
@@ -63,10 +64,10 @@ class Checksum < Sensu::Plugin::Check::CLI
       hash = IO.read(config[:hashfile]).chomp
     else
       hash = config[:hash] || Digest::SHA2.file(files.first).hexdigest
-    end 
+    end
     
     errors = []
-
+    
     files.each do |file|
       if File.exist?(file)
         file_hash = Digest::SHA2.file(file).hexdigest.chomp


### PR DESCRIPTION
In response to your reply I created a new option (with -H) that accepts a file containing a hash instead of a hash, whereas the -h option that you had remains unchanged so it doesn't disturb anyone's current configurations.
