### PR TITLE
Add metric-nfsstat.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Added 'metrics-nfsstat.rb' for collecting nfsstat metrics
 
+### Changed
+- Renamed metric-{dirsize,filename} to metrics-{dirsize,filename}
+
 ## [0.1.0] - 2015-08-04
 ### Added
 - Added new checks for file and directory size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- nothing
+### Added
+- Added 'metric-nfsstat.rb' for collecting nfsstat metrics
 
 ## [0.1.0] - 2015-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Added 'metric-nfsstat.rb' for collecting nfsstat metrics
+- Added 'metrics-nfsstat.rb' for collecting nfsstat metrics
 
 ## [0.1.0] - 2015-08-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
  * bin/check-fs-writable.rb
  * bin/check-mtime.rb
  * bin/check-tail.rb
- * bin/metric-dirsize.rb
- * bin/metric-filesize.rb
+ * bin/metrics-dirsize.rb
+ * bin/metrics-filesize.rb
  * bin/metrics-nfsstat.rb
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
  * bin/check-tail.rb
  * bin/metric-dirsize.rb
  * bin/metric-filesize.rb
- * bin/metric-nfsstat.rb
+ * bin/metrics-nfsstat.rb
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
  * bin/check-tail.rb
  * bin/metric-dirsize.rb
  * bin/metric-filesize.rb
+ * bin/metric-nfsstat.rb
 
 ## Usage
 

--- a/bin/metric-nfsstat.rb
+++ b/bin/metric-nfsstat.rb
@@ -1,0 +1,48 @@
+#! /usr/bin/env ruby
+#
+#   metric-nfsstat
+#
+# DESCRIPTION:
+#   Simple wrapper around `nfsstat` for getting nfs server/client stats.
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2016 Mitsutoshi Aoe
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'socket'
+require 'sensu-plugin/metric/cli'
+
+class NfsstatMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.nfsstat"
+  def run
+    output = `/usr/sbin/nfsstat -l`
+
+    output.each_line do |line|
+      next unless /^nfs\s+(.+):\s+(\d+)/ =~ line
+      key = Regexp.last_match[1].split.join('.')
+      val = Regexp.last_match[2].to_i
+      output "#{config[:scheme]}.#{key}", val
+    end
+
+    ok
+  end
+end

--- a/bin/metric-nfsstat.rb
+++ b/bin/metric-nfsstat.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 #   metric-nfsstat
 #
@@ -33,6 +33,7 @@ class NfsstatMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-s SCHEME',
          long: '--scheme SCHEME',
          default: "#{Socket.gethostname}.nfsstat"
+
   def run
     output = `/usr/sbin/nfsstat -l`
 

--- a/bin/metrics-dirsize.rb
+++ b/bin/metrics-dirsize.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-#   metric-dirsize
+#   metrics-dirsize
 #
 # DESCRIPTION:
 #   Simple wrapper around `du` for getting directory size stats,
@@ -18,7 +18,7 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   metric-dirsize.rb --dir /var/backups/postgres/ --real
+#   metrics-dirsize.rb --dir /var/backups/postgres/ --real
 #
 # NOTES:
 #

--- a/bin/metrics-filesize.rb
+++ b/bin/metrics-filesize.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-#   metric-filesize
+#   metrics-filesize
 #
 # DESCRIPTION:
 #   Simple wrapper around `stat` for getting file size stats,

--- a/bin/metrics-nfsstat.rb
+++ b/bin/metrics-nfsstat.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-#   metric-nfsstat
+#   metrics-nfsstat
 #
 # DESCRIPTION:
 #   Simple wrapper around `nfsstat` for getting nfs server/client stats.

--- a/bin/metrics-nfsstat.rb
+++ b/bin/metrics-nfsstat.rb
@@ -35,7 +35,11 @@ class NfsstatMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{Socket.gethostname}.nfsstat"
 
   def run
-    output = `/usr/sbin/nfsstat -l`
+    begin
+      output = `/usr/sbin/nfsstat -l`
+    rescue Errno::ENOENT => err
+      unknown err
+    end
 
     output.each_line do |line|
       next unless /^nfs\s+(.+):\s+(\d+)/ =~ line


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [x] Add the plugin to the README
- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

This metric plugin runs the `nfsstat` command and prints the metrics. Example output follows:

```
% /opt/sensu/embedded/bin/ruby bin/metric-nfsstat.rb --scheme nfsstat
nfsstat.v3.client.total 66 1456189379
nfsstat.v3.client.getattr 20 1456189379
nfsstat.v3.client.lookup 6 1456189379
nfsstat.v3.client.access 16 1456189379
nfsstat.v3.client.fsstat 12 1456189379
nfsstat.v3.client.fsinfo 8 1456189379
nfsstat.v3.client.pathconf 4 1456189379
nfsstat.v4.client.total 846081 1456189379
nfsstat.v4.client.read 42583 1456189379
nfsstat.v4.client.open 2 1456189379
nfsstat.v4.client.open_conf 2 1456189379
nfsstat.v4.client.close 1 1456189379
nfsstat.v4.client.fsinfo 11 1456189379
nfsstat.v4.client.renew 8 1456189379
nfsstat.v4.client.setclntid 2 1456189379
nfsstat.v4.client.confirm 2 1456189379
nfsstat.v4.client.access 144 1456189379
nfsstat.v4.client.getattr 803248 1456189379
nfsstat.v4.client.lookup 22 1456189379
nfsstat.v4.client.lookup_root 12 1456189379
nfsstat.v4.client.pathconf 8 1456189379
nfsstat.v4.client.statfs 8 1456189379
nfsstat.v4.client.readdir 4 1456189379
nfsstat.v4.client.server_caps 19 1456189379
nfsstat.v4.client.secinfo 5 1456189379
```
#### Known Compatablity Issues

I've only tested this on Ubuntu Trusty. No known issues so far.
