### PR TITLE
Errno exception handling

### DIFF
--- a/bin/check-fs-writable.rb
+++ b/bin/check-fs-writable.rb
@@ -143,6 +143,9 @@ class CheckFSWritable < Sensu::Plugin::Check::CLI
       file.close
       file.unlink
     end
+  rescue Errno::EPERM, Errno::ENOENT, Errno::EIO, Errno::EACCES, Errno::ENOSPC, Errno::EROFS => e
+  $stderr.puts "Caught the exception: #{e}"
+  exit -1
   end
 
   # Main function


### PR DESCRIPTION
#### Proposed solution to following

[sensu-plugins-filesystem-checks/issues/14](https://github.com/sensu-plugins/sensu-plugins-filesystem-checks/issues/14)
#### Purpose

Adds few Errno exception handling to **check-fs-writable** check
- Refer [errno-exceptions](http://blog.honeybadger.io/understanding-rubys-strange-errno-exceptions/) for more details on Errno types
- Errno types included in this pull request are only specific to what errors the check might encounter. Other/out-of-ordinary exceptions remains untouched.
#### Known Compatablity Issues

None I am aware of.
